### PR TITLE
Allow overriding executable parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN apk add --update git go && \
     rm -rf /opt/logstash-forwarder/.git && \
     apk del -r git go
 
-CMD ["/opt/logstash-forwarder/logstash-forwarder", "-config", "/etc/logstash-forwarder/config.json"]
+ENTRYPOINT ["/opt/logstash-forwarder/logstash-forwarder"]
+CMD ["-config", "/etc/logstash-forwarder/config.json"]


### PR DESCRIPTION
Setting the executable as the ENTRYPOINT and moving the `config` flag to CMD allows to easily override the flags passed to the executable.

Example:

```
docker run apopelo/logstash-forwarder -config /etc/lf-config.json -spool-size=2048
```
